### PR TITLE
Add interview assistant demo using OpenAI Live API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Codex-test
 
-This repository contains a simple Duck Hunt clone implemented in HTML5 Canvas.
+This repository contains two demos:
 
-## How to Run
+1. **Duck Hunt Clone** – a simple game built with HTML5 Canvas.
+2. **Interview Assistant** – an example Node.js project that uses the OpenAI Live API to simulate a real-time interview with an AI candidate.
+
+## Duck Hunt
 Open `index.html` in a modern web browser. Use the mouse to shoot ducks. Each round gives you three bullets. Try to shoot the duck before you run out of bullets!
+
+## Interview Assistant
+To run the interview assistant you need Node.js installed. The assistant streams answers from the OpenAI API using websockets.
+
+```bash
+cd interview-assistant
+npm install
+OPENAI_API_KEY=your-key npm start
+```
+
+Then open `http://localhost:3000` in your browser and ask questions in the text box. Answers will appear in real time.

--- a/interview-assistant/.gitignore
+++ b/interview-assistant/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/interview-assistant/client/index.html
+++ b/interview-assistant/client/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Interview Assistant</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #log { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: auto; white-space: pre-line; }
+  </style>
+</head>
+<body>
+  <h1>Interview Assistant</h1>
+  <div id="log"></div>
+  <input id="question" type="text" placeholder="Ask a question" style="width:80%">
+  <button id="send">Send</button>
+
+  <script>
+    const ws = new WebSocket(`ws://${location.host}`);
+    const log = document.getElementById('log');
+    const input = document.getElementById('question');
+    const sendBtn = document.getElementById('send');
+
+    ws.addEventListener('message', (event) => {
+      log.textContent += event.data;
+    });
+
+    sendBtn.addEventListener('click', () => {
+      const text = input.value.trim();
+      if (!text) return;
+      log.textContent += '\n> ' + text + '\n';
+      ws.send(text);
+      input.value = '';
+    });
+  </script>
+</body>
+</html>

--- a/interview-assistant/package.json
+++ b/interview-assistant/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "interview-assistant",
+  "version": "0.1.0",
+  "description": "Realtime interview assistant using OpenAI Live API",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.15.1",
+    "openai": "^4.23.0"
+  }
+}

--- a/interview-assistant/server.js
+++ b/interview-assistant/server.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const { WebSocketServer } = require('ws');
+const { OpenAI } = require('openai');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.static(__dirname + '/client'));
+
+const server = app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+const wss = new WebSocketServer({ server });
+
+// Replace with your OpenAI API key
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+wss.on('connection', ws => {
+  let openaiStream;
+
+  ws.on('message', async msg => {
+    const text = msg.toString();
+    // Start new session with system prompt
+    openaiStream = await openai.chat.completions.create({
+      model: 'gpt-4o-realtime',
+      messages: [
+        { role: 'system', content: 'Ты — опытный iOS-разработчик с 5-летним опытом. Ты участвуешь в собеседовании на позицию Senior iOS Engineer. Отвечай так, как будто ты настоящий человек: используй примеры из практики, упоминай технологии (Swift, Combine, UIKit, AVKit), избегай абстракций. Отвечай уверенно, иногда переспрашивай или уточняй вопрос, если он неясен.' },
+        { role: 'user', content: text }
+      ],
+      stream: true
+    });
+
+    for await (const part of openaiStream) {
+      const token = part.choices[0]?.delta?.content || '';
+      if (token) {
+        ws.send(token);
+      }
+    }
+
+    ws.send('\n');
+  });
+
+  ws.on('close', () => {
+    if (openaiStream) {
+      openaiStream.controller.abort();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- set up a new `interview-assistant` project with Node.js
- implement a basic Express/WebSocket server that streams from OpenAI
- add a minimal browser client to send questions
- document how to run the demo in README

## Testing
- `node interview-assistant/server.js` *(fails: cannot find module 'express')*
- `npm install` in `interview-assistant` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686836e018f083319229a15e03d695e9